### PR TITLE
feat: hide other tmux panes when entering zen

### DIFF
--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -53,8 +53,10 @@ function M.tmux(state, disable, opts)
   end
   if disable then
     vim.fn.system([[tmux set -g status off]])
+    vim.fn.system([[tmux list-panes -F '\#F' | grep -q Z || tmux resize-pane -Z]])
   else
     vim.fn.system([[tmux set -g status on]])
+    vim.fn.system([[tmux list-panes -F '\#F' | grep -q Z && tmux resize-pane -Z]])
   end
 end
 


### PR DESCRIPTION
If there are more panes in the tmux window, they will be hidden when zen-mode is entered. 

Inspired by Goyo.vim