### PR TITLE
fix: take gitsigns config from inner module

### DIFF
--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.gitsigns(state, disable)
   local gs = require("gitsigns")
-  local config = gs.config
+  local config = require("gitsigns.config").config
   if disable then
     state.signcolumn = config.signcolumn
     state.numhl = config.numhl


### PR DESCRIPTION
Fixing regression after https://github.com/folke/zen-mode.nvim/commit/21ca264c6ae934ceac220cf719c0ed6c0216b057#diff-79fe7b2f00da5c112ea6be1547972b941947fc4444103e14bc9f9548de1f8875L5