### PR TITLE
fix: transparent background

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -202,6 +202,7 @@ function M.fix_hl(win, normal)
   end
   normal = normal or "Normal"
   vim.cmd("setlocal winhl=NormalFloat:" .. normal)
+  vim.cmd("setlocal winblend=0")
   vim.cmd([[setlocal fcs=eob:\ ]])
   -- vim.api.nvim_win_set_option(win, "winhighlight", "NormalFloat:" .. normal)
   -- vim.api.nvim_win_set_option(win, "fcs", "eob: ")


### PR DESCRIPTION
If the default `winblend` is set to, for example, `20`, ZenMode's background inherit this transparency. This PR fixes it :slightly_smiling_face:

I also found an issue where the cursor jumps one line down every time I open ZenMode. I assume you're setting the cursor's position in ZenMode's buffer to keep it at the same line, but I can really figure out where this is in the code (though I'm not that familiar with vim/nvim's functions).