### PR TITLE
allow the ZenMode command to be followed by a "|" and another command

### DIFF
--- a/plugin/zen-mode.vim
+++ b/plugin/zen-mode.vim
@@ -4,4 +4,4 @@ if !has('nvim-0.5')
   echohl None
   finish
 endif
-command! ZenMode lua require("zen-mode").toggle()
+command! -bar ZenMode lua require("zen-mode").toggle()


### PR DESCRIPTION
I'm trying to run this command: `:ZenMode | q`. What I expect to happen is that ZenMode exits and the buffer quits. What actually happens is that I get the error `E488: Trailing characters`. This error occurs whenever a command cannot be followed by a "|" and another command. 

In this PR I've provided a fix to this issue by adding the `-bar` flag to the command. See `help :command-bar` for more information about this flag.