### PR TITLE
Improvements to the tmux experience

### DIFF
--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -63,10 +63,21 @@ function M.tmux(state, disable, opts)
     return
   end
   if disable then
+    local status_raw = vim.fn.system([[tmux show status]])
+    local window_pane_border_raw = vim.fn.system([[tmux show -w pane-border-status]])
+    state.status = vim.split(vim.trim(status_raw), " ")[2]
+    state.pane = vim.split(vim.trim(window_pane_border_raw), " ")[2]
+
+    vim.fn.system([[tmux set -w pane-border-status off]])
     vim.fn.system([[tmux set status off]])
     vim.fn.system([[tmux list-panes -F '\#F' | grep -q Z || tmux resize-pane -Z]])
   else
-    vim.fn.system([[tmux set status on]])
+    if type(state.pane) == "string" then
+      vim.fn.system(string.format([[tmux set -w pane-border-status %s]], state.pane))
+    else
+      vim.fn.system([[tmux set -uw pane-border-status]])
+    end
+    vim.fn.system(string.format([[tmux set status %s]], state.status))
     vim.fn.system([[tmux list-panes -F '\#F' | grep -q Z && tmux resize-pane -Z]])
   end
 end

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -114,6 +114,13 @@ end
 function M.fix_layout(win_resized)
   if M.is_open() then
     if win_resized then
+      vim.api.nvim_win_set_config(
+        M.win,
+        vim.tbl_extend("force", vim.api.nvim_win_get_config(M.win), {
+          width = M.resolve(vim.o.columns, M.opts.window.width),
+          height = M.height(),
+        })
+      )
       vim.api.nvim_win_set_config(M.bg_win, { width = vim.o.columns, height = M.height() })
     end
     local height = vim.api.nvim_win_get_height(M.win)

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -114,13 +114,8 @@ end
 function M.fix_layout(win_resized)
   if M.is_open() then
     if win_resized then
-      vim.api.nvim_win_set_config(
-        M.win,
-        vim.tbl_extend("force", vim.api.nvim_win_get_config(M.win), {
-          width = M.resolve(vim.o.columns, M.opts.window.width),
-          height = M.height(),
-        })
-      )
+      local l = M.layout(M.opts)
+      vim.api.nvim_win_set_config(M.win, { width = l.width, height = l.height })
       vim.api.nvim_win_set_config(M.bg_win, { width = vim.o.columns, height = M.height() })
     end
     local height = vim.api.nvim_win_get_height(M.win)


### PR DESCRIPTION
This addresses several issues I've noticed using the tmux plugin:

- Hide the [pane border status](https://man7.org/linux/man-pages/man1/tmux.1.html#:~:text=pane%2Dborder%2Dstatus%20%5Boff%20%7C%20top%20%7C%20bottom%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Turn%20pane%20border%20status%20lines%20off%20or%20set%20their%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20position.) line for the current window; it was still displaying in zen mode.
- Preserve the initial values of the status (and now pane-border-status) options. Before, zen mode would naively re-enable the status line on close, but now it stores the initial values before making changes, and restores them when zen mode closes.
- Properly handle resizing after zooming the tmux pane. The pre-zoom width and height of the vim instance's tmux pane seem to act as constraints on the width and height of the zen mode window (I don't see a better fix than what I've got in this PR but I'm pretty new to the code).