### PR TITLE
fix: `window.backdrop` option is ignored in `.toggle()` API (#77)

### DIFF
--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -53,10 +53,11 @@ local defaults = {
 ---@type ZenOptions
 M.options = {}
 
-function M.colors()
+function M.colors(options)
+  options = options or M.options
   local normal = util.get_hl("Normal")
   if normal and normal.background then
-    local bg = util.darken(normal.background, M.options.window.backdrop)
+    local bg = util.darken(normal.background, options.window.backdrop)
     vim.cmd(("highlight ZenBg guibg=%s guifg=%s"):format(bg, bg))
   end
 end

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -74,6 +74,7 @@ end
 
 function M.open(opts)
   if not M.is_open() then
+    config.colors(opts)
     -- close any possible remnants from a previous session
     -- shouldn't happen, but just in case
     M.close()

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -74,7 +74,6 @@ end
 
 function M.open(opts)
   if not M.is_open() then
-    config.colors(opts)
     -- close any possible remnants from a previous session
     -- shouldn't happen, but just in case
     M.close()
@@ -148,6 +147,7 @@ end
 --- @param opts ZenOptions
 function M.create(opts)
   opts = vim.tbl_deep_extend("force", {}, config.options, opts or {})
+  config.colors(opts)
   M.opts = opts
   M.state = {}
   M.parent = vim.api.nvim_get_current_win()


### PR DESCRIPTION
fixes #76
fixes #77
- `config.colors()` now has optional parameter `options`.
- `view.open()` will call `config.colors()` when entering zen-mode.

This will allow use to:
- have correct highlight group (`ZenBG`) after colorscheme change.
- respect `backdrop` value passed to `require("zen-mode").toggle()`