### PR TITLE
feat: use transparent bg when Normal hl group not having bg

### DIFF
--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -63,9 +63,13 @@ M.options = {}
 function M.colors(options)
   options = options or M.options
   local normal = util.get_hl("Normal")
-  if normal and normal.background then
-    local bg = util.darken(normal.background, options.window.backdrop)
-    vim.cmd(("highlight ZenBg guibg=%s guifg=%s"):format(bg, bg))
+  if normal then
+    if normal.background then
+      local bg = util.darken(normal.background, options.window.backdrop)
+      vim.cmd(("highlight ZenBg guibg=%s guifg=%s"):format(bg, bg))
+    else
+      vim.cmd("highlight link ZenBg Normal")
+    end
   end
 end
 


### PR DESCRIPTION
When `Normal` highlight group doesn't have a `background` property, `ZenBg` highlight group is not created, so `NormalFloat`'s background color is used.

I think when `Normal`'s bg is transparent, zen-mode's bg also should be transparent.

**before**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/43514606/215956392-15659fa0-e6a6-429f-a2c2-a64a224dd51f.png">

**after**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/43514606/215956757-866ee9ff-7c4b-46dd-b032-267b0a0e6d74.png">

