### PR TITLE
Make fold and vertical fcs zen

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -218,7 +218,7 @@ function M.fix_hl(win, normal)
   normal = normal or "Normal"
   vim.cmd("setlocal winhl=NormalFloat:" .. normal)
   vim.cmd("setlocal winblend=0")
-  vim.cmd([[setlocal fcs=eob:\ ]])
+  vim.cmd([[setlocal fcs=eob:\ ,fold:\ ,vert:\]])
   -- vim.api.nvim_win_set_option(win, "winhighlight", "NormalFloat:" .. normal)
   -- vim.api.nvim_win_set_option(win, "fcs", "eob: ")
   vim.api.nvim_set_current_win(cwin)


### PR DESCRIPTION
Changes
![IMG_0071](https://user-images.githubusercontent.com/50712700/220873936-ea68f5c4-6aa3-47d3-9235-0b804f167fe2.jpeg)

To
![IMG_0065](https://user-images.githubusercontent.com/50712700/220873969-4a655d0a-7708-48f0-85d2-6e164e9bf576.jpeg)

Partially addresses issue https://github.com/folke/zen-mode.nvim/issues/55
Perhaps `foldopen:▾,foldsep:‾,foldclose:▸` these are zen-enough.