### PR TITLE
Don't perform `norm! zz` on terminal buffers

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -178,7 +178,9 @@ function M.create(opts)
 
   local buf = vim.api.nvim_get_current_buf()
   M.win = vim.api.nvim_open_win(buf, true, win_opts)
-  vim.cmd([[norm! zz]])
+  if not vim.bo[buf].buftype == "terminal" then
+    vim.cmd([[norm! zz]])
+  end
   M.fix_hl(M.win)
 
   for k, v in pairs(opts.window.options or {}) do


### PR DESCRIPTION
Hey!

Was having an issue where I couldn't stay in terminal mode if I toggled on a terminal buffer due to the `norm!` that's performed on toggle.

This blocks the `norm` for specifically terminal buffers.

100% scratch my own itch so cool if you'd rather not.

Thanks for all the great work :)