### PR TITLE
feat: assign filetype to background buffer

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -153,6 +153,7 @@ function M.create(opts)
   M.parent = vim.api.nvim_get_current_win()
 
   M.bg_buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_option(M.bg_buf, "filetype", "zenmode-bg")
   local ok
   ok, M.bg_win = pcall(vim.api.nvim_open_win, M.bg_buf, false, {
     relative = "editor",


### PR DESCRIPTION
## Summary

Assigns a filetype (`zenmode-bg`) to the background buffer created by zen-mode.

> Why?

I use a [utility](https://github.com/ditsuke/nvim-config/blob/main/lua/ditsuke/utils/ui.lua#L21-L45) to close floating windows. This utility interferes with zen-mode's background window so it helps if it has a filetype I can use to filter it out.
