### PR TITLE
fix: Fix highlights on WinEnter

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -246,6 +246,7 @@ function M.on_win_enter()
       end
     end, 10)
   end
+  M.fix_hl(win)
 end
 
 return M


### PR DESCRIPTION
## Summary
Call `zen-mode.view.fix_hl` on WinEnter events.

## What it fixes
On usage with plugins like levouh/tint.nvim or shade.nvim that manipulate
window highlights, zen-mode window's highlights can break when switching
back from floating windows like Telescope. By fixing highlights on the
WinEnter event, we ensure that we're not affected by such manipulations
and play nicely with these plugins.

