### PR TITLE
feat(statusline): Turn on/off statusline in zen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Install the plugin with your preferred package manager:
       enabled = true,
       ruler = false, -- disables the ruler text in the cmd line area
       showcmd = false, -- disables the command in the last line of the screen
+      -- you may turn on/off statusline in zen mode by setting 'laststatus' 
+      -- statusline will be shown only if 'laststatus' == 3
+      laststatus = 0, -- turn off the statusline in zen mode
     },
     twilight = { enabled = true }, -- enable to start Twilight when zen mode opens
     gitsigns = { enabled = false }, -- disables git signs

--- a/doc/zen-mode.nvim.txt
+++ b/doc/zen-mode.nvim.txt
@@ -101,6 +101,9 @@ CONFIGURATION                           *zen-mode.nvim-zen-mode-configuration*
           enabled = true,
           ruler = false, -- disables the ruler text in the cmd line area
           showcmd = false, -- disables the command in the last line of the screen
+          -- you may turn on/off statusline in zen mode by setting the 'laststatus' 
+          -- statusline will be shown only if 'laststatus' == 3
+          laststatus = 0, -- turn off statusline in zen mode
         },
         twilight = { enabled = true }, -- enable to start Twilight when zen mode opens
         gitsigns = { enabled = false }, -- disables git signs

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -94,7 +94,8 @@ function M.round(num)
 end
 
 function M.height()
-  return vim.o.lines - vim.o.cmdheight
+  local height = vim.o.lines - vim.o.cmdheight
+  return (vim.o.laststatus == 3) and height - 1 or height
 end
 
 function M.resolve(max, value)
@@ -151,6 +152,8 @@ function M.create(opts)
   M.opts = opts
   M.state = {}
   M.parent = vim.api.nvim_get_current_win()
+  -- should apply before calculate window's height to be able handle 'laststatus' option  
+  M.plugins_on_open()
 
   M.bg_buf = vim.api.nvim_create_buf(false, true)
   local ok
@@ -165,6 +168,7 @@ function M.create(opts)
     zindex = opts.zindex - 10,
   })
   if not ok then
+    M.plugins_on_close()
     util.error("could not open floating window. You need a Neovim build that supports zindex (May 15 2021 or newer)")
     M.bg_win = nil
     return
@@ -185,7 +189,6 @@ function M.create(opts)
     vim.api.nvim_win_set_option(M.win, k, v)
   end
 
-  M.plugins_on_open()
   if type(opts.on_open) == "function" then
     opts.on_open(M.win)
   end


### PR DESCRIPTION
Closes https://github.com/folke/zen-mode.nvim/issues/47

**Feature:**
This PR brings an option to show statusline in zen mode, but only if `laststatus` == 3, that is when global statusline is used.
This done because showing statusline per window would look weird and only global mode looks reasonable.

Also, it's possible to manage statusline visibility only for zen mode changing configuration:
```lua
{
   ...
  plugins = {
    -- disable some global vim options (vim.o...)
    -- comment the lines to not apply the options
    options = {
      enabled = true,
       ...
      -- you may turn on/off statusline in zen mode by setting the 'laststatus' 
      -- statusline will be shown only if 'laststatus' == 3
      laststatus = 0, -- turn off statusline in zen mode
    }
...
}

```

**Preview**
<img width="1212" alt="Screenshot 2023-10-05 at 12 59 30" src="https://github.com/folke/zen-mode.nvim/assets/6939832/3ec4cfc5-3755-4293-8a41-65961b276c11">
