### PR TITLE
fix: tmux+wezterm plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ wezterm.on('user-var-changed', function(window, pane, name, value)
 end)
 ```
 
+If you need this functionality within tmux, you need to add the following option
+to your tmux config:
+
+```zsh
+set-option -g allow-passthrough on
+```
+
 See also: https://github.com/wez/wezterm/discussions/2550
 
 ## Inspiration

--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -67,9 +67,17 @@ end
 function M.wezterm(state, disable, opts)
   local stdout = vim.loop.new_tty(1, false)
   if disable then
-    stdout:write(('\x1b]1337;SetUserVar=%s=%s\b'):format('ZEN_MODE', vim.fn.system({ 'base64' }, tostring(opts.font))))
+    -- Requires tmux setting or no effect: set-option -g allow-passthrough on
+    stdout:write(
+      ("\x1bPtmux;\x1b\x1b]1337;SetUserVar=%s=%s\b\x1b\\"):format(
+        "ZEN_MODE",
+        vim.fn.system({ "base64" }, tostring(opts.font))
+      )
+    )
   else
-    stdout:write(('\x1b]1337;SetUserVar=%s=%s\b'):format('ZEN_MODE', vim.fn.system({ 'base64' }, '-1')))
+    stdout:write(
+      ("\x1bPtmux;\x1b\x1b]1337;SetUserVar=%s=%s\b\x1b\\"):format("ZEN_MODE", vim.fn.system({ "base64" }, "-1"))
+    )
   end
   vim.cmd([[redraw]])
 end


### PR DESCRIPTION
Sends passthrough escape sequence to tmux, still works the same outside of tmux.

This allows the wezterm plugin to work correctly inside of tmux.

