### PR TITLE
fix: add default to ZenBg to allow customization

### DIFF
--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -73,9 +73,9 @@ function M.colors(options)
   if normal then
     if normal.background then
       local bg = util.darken(normal.background, options.window.backdrop)
-      vim.cmd(("highlight ZenBg guibg=%s guifg=%s"):format(bg, bg))
+      vim.cmd(("highlight default ZenBg guibg=%s guifg=%s"):format(bg, bg))
     else
-      vim.cmd("highlight link ZenBg Normal")
+      vim.cmd("highlight default link ZenBg Normal")
     end
   end
 end


### PR DESCRIPTION
Hi @folke,

I'd like to customize the `ZenBg` highlight group. Currently, `ZenBg` will get overwritten by `M.colors`. Adding `default` will ignore the highlight group updates if they are already defined.

## before fix
![before-default](https://github.com/folke/zen-mode.nvim/assets/10135646/5f6c1b72-3154-49fb-8016-978157d2fc54)


## after fix
![after-default](https://github.com/folke/zen-mode.nvim/assets/10135646/606eb98b-d351-42b2-a9f6-ab9f19b5c918)


