### PR TITLE
Update set_option calls to use the recommended APIs

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -186,7 +186,7 @@ function M.create(opts)
   M.fix_hl(M.win, false)
 
   for k, v in pairs(opts.window.options or {}) do
-    vim.api.nvim_win_set_option(M.win, k, v)
+    vim.api.nvim_set_option_value(k, v, { scope = "local", win = M.win })
   end
 
   if type(opts.on_open) == "function" then


### PR DESCRIPTION
I was having an issue where fillchars would be overriden when I exited zenmode. It turns out that this was actually an issue in another plugin---I had ZenMode change colorschemes with a hook, and actually that set an option in an unsafe way---but I assumed that ZenMode was the source of the problem and wound up writing this code before tracing the source it to the other plugin, so I figured that I might as well upstream it.