### PR TITLE
feat(plugins): add the ability to disable todo-comments.nvim in zen-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Install the plugin with your preferred package manager:
     twilight = { enabled = true }, -- enable to start Twilight when zen mode opens
     gitsigns = { enabled = false }, -- disables git signs
     tmux = { enabled = false }, -- disables the tmux statusline
+    todo = { enabled = false }, -- if set to "true", todo-comments.nvim highlights will be disabled
     -- this will change the font size on kitty when in zen mode
     -- to make this work, you need to set the following kitty options:
     -- - allow_remote_control socket-only

--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -35,6 +35,7 @@ local defaults = {
     gitsigns = { enabled = false }, -- disables git signs
     tmux = { enabled = false }, -- disables the tmux statusline
     diagnostics = { enabled = false }, -- disables diagnostics
+    todo = { enabled = false }, -- if set to "true", todo-comments.nvim highlights will be disabled
     -- this will change the font size on kitty when in zen mode
     -- to make this work, you need to set the following kitty options:
     -- - allow_remote_control socket-only

--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -131,4 +131,15 @@ function M.diagnostics(state, disable)
   end
 end
 
+function M.todo(state, disable)
+  if disable then
+    state.todo = require("todo-comments.highlight").enabled
+    require("todo-comments").disable()
+  else
+    if state.todo then
+      require("todo-comments").enable()
+    end
+  end
+end
+
 return M


### PR DESCRIPTION
I'm an avid and happy user of the [todo-comments.nvim](https://github.com/folke/todo-comments.nvim) plugin, but when writing (text, not code) in zen mode, I personally find the highlights to be distracting sometimes. Since [todo-comments.nvim](https://github.com/folke/todo-comments.nvim) is also part of the @folke ecosystem of plugins, I thought an option to explicitly disable the highlights made by the plugin would make a nice addition to the zen-mode.nvim.