### PR TITLE
Main window reflects navigation in zen mode window

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -233,6 +233,9 @@ function M.on_buf_win_enter()
   if vim.api.nvim_get_current_win() == M.win then
     M.fix_hl(M.win)
 
+    -- load buffer into parent window to set default options if not already loaded
+    vim.api.nvim_win_set_buf(M.parent, vim.api.nvim_get_current_buf())
+
     -- ensure zen mode options are set when switching buffers
     for k, v in pairs(M.opts.window.options or {}) do
       vim.api.nvim_win_set_option(M.win, k, v)

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -232,6 +232,11 @@ end
 function M.on_buf_win_enter()
   if vim.api.nvim_get_current_win() == M.win then
     M.fix_hl(M.win)
+
+    -- ensure zen mode options are set when switching buffers
+    for k, v in pairs(M.opts.window.options or {}) do
+      vim.api.nvim_win_set_option(M.win, k, v)
+    end
   end
 end
 


### PR DESCRIPTION
Right now if you navigate to another file while in zen mode and leave zen mode, the original window doesn't move. This fix is from https://github.com/subjective/zen-mode.nvim 