### PR TITLE
fix: allow highlight group overwrite

### DIFF
--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -73,7 +73,7 @@ function M.colors(options)
   if normal then
     if normal.background then
       local bg = util.darken(normal.background, options.window.backdrop)
-      vim.cmd(("highlight default ZenBg guibg=%s guifg=%s"):format(bg, bg))
+      vim.cmd(("highlight ZenBg guibg=%s guifg=%s"):format(bg, bg))
     else
       vim.cmd("highlight default link ZenBg Normal")
     end


### PR DESCRIPTION
Related issue: #115.

Allows the `ZenBg` highlight group to be overwritten so the `window.backdrop` option is respected.