### PR TITLE
Fix syntax error in Zen Mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Install the plugin with your preferred package manager:
     neovide = {
         enabled = false,
         -- Will multiply the current scale factor by this number
-        scale = 1.2
+        scale = 1.2,
         -- disable the Neovide animations while in Zen mode
         disable_animations = {
                 neovide_animation_length = 0,


### PR DESCRIPTION
## Description
Added missing comma in the provided default configuration for Zen Mode plugin, resolving setup issues.

## Related Issue(s)

## Screenshots
![image](https://github.com/user-attachments/assets/cd7cf808-a4bb-41a7-8778-4c03d861306f)
