### PR TITLE
feat: konsole plugin with fullscreen and profile switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Distraction-free coding for Neovim >= 0.5
   - increase [Alacritty](https://alacritty.org/) font-size
   - increase [wezterm](https://wezfurlong.org/wezterm/) font-size
   - increase [Neovide](https://neovide.dev/) scale factor and disable animations
+  - switch to a preconfigured profile in [Konsole](https://konsole.kde.org/)
 - **Zen Mode** is automatically closed when a new non-floating window is opened
 - works well with plugins like [Telescope](https://github.com/nvim-telescope/telescope.nvim) to open a new buffer inside the Zen window
 - close the Zen window with `:ZenMode`, `:close` or `:quit`
@@ -129,6 +130,17 @@ Install the plugin with your preferred package manager:
                 neovide_cursor_animation_length = 0,
                 neovide_cursor_vfx_mode = "",
             }
+    },
+    -- this will change the profile in Konsole when in Zen mode and/or make it fullscreen
+    konsole = {
+      enabled = true,
+      -- this will turn the window borderless fullscreen on enter and back to
+      -- normal on exit
+      fullscreen = true,
+      -- when set to true, this will switch to the profile called "Zen" when
+      -- entering Zen mode and back to the original profile on exit; can be set
+      -- to a string to use a specific profile instead
+      profile = false,
     },
   },
   -- callback where you can add custom code when the Zen window opens

--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -75,6 +75,17 @@ local defaults = {
         neovide_cursor_vfx_mode = "",
       },
     },
+    -- this will change the profile in Konsole when in Zen mode and/or make it fullscreen
+    konsole = {
+      enabled = true,
+      -- this will turn the window borderless fullscreen on enter and back to
+      -- normal on exit
+      fullscreen = true,
+      -- when set to true, this will switch to the profile called "Zen" when
+      -- entering Zen mode and back to the original profile on exit; can be set
+      -- to a string to use a specific profile instead
+      profile = false,
+    },
   },
   -- callback where you can add custom code when the zen window opens
   on_open = function(_win) end,


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Adds Zen mode integration to [Konsole](https://konsole.kde.org/), making it fullscreen and (possibly) changing to a different pre-configured profile using qdbus.

I wish I could find a way to change font size or background opacity rather than switching profiles dynamically, but I could not find a way.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
None, new feature

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
Functioning integrated Zen mode in Neovim on Konsole.
![image](https://github.com/user-attachments/assets/644b1163-7676-42e5-b34c-9ea4410cd588)
