### PR TITLE
fix: tmux+wezterm escape sequences

### DIFF
--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -65,18 +65,20 @@ end
 
 -- changes the wezterm font size
 function M.wezterm(state, disable, opts)
-  local stdout = vim.loop.new_tty(1, false)
   if disable then
     -- Requires tmux setting or no effect: set-option -g allow-passthrough on
-    stdout:write(
-      ("\x1bPtmux;\x1b\x1b]1337;SetUserVar=%s=%s\b\x1b\\"):format(
+    vim.cmd(
+      ([[call chansend(v:stderr, "\033Ptmux;\033\033]1337;SetUserVar=%s=%s\007\033\\")]]):format(
         "ZEN_MODE",
-        vim.fn.system({ "base64" }, tostring(opts.font))
+        vim.fn.system({ "base64", "-w", "0" }, tostring(opts.font))
       )
     )
   else
-    stdout:write(
-      ("\x1bPtmux;\x1b\x1b]1337;SetUserVar=%s=%s\b\x1b\\"):format("ZEN_MODE", vim.fn.system({ "base64" }, "-1"))
+    vim.cmd(
+      ([[call chansend(v:stderr, "\033Ptmux;\033\033]1337;SetUserVar=%s=%s\007\033\\")]]):format(
+        "ZEN_MODE",
+        vim.fn.system({ "base64", "-w", "0" }, "-1")
+      )
     )
   end
   vim.cmd([[redraw]])


### PR DESCRIPTION
This fixes two problems with the previous implementation, first: use the `-w0` argument to the `base64` command to disable line wrapping so it doesn't output a new line character.

second: NeoVim seems to clear escape sequences before sending it into stdout, the only workaround I cound find was to use the call command to the chansend function.

Relevant links:
https://github.com/neovim/neovim/issues/1496
https://github.com/neovim/neovim/issues/2765

https://github.com/user-attachments/assets/a66a7d06-20dc-4c37-abbe-0d0e5330fedc

*Video illustrates the toggling of ZenMode with the fix applied and NeoVim being able to change WezTerms font size.