### PR TITLE
fix(main): fix EndOfBuffer highlight as well

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -221,7 +221,7 @@ function M.fix_hl(win, normal)
     vim.api.nvim_set_current_win(win)
   end
   normal = normal or "Normal"
-  vim.cmd("setlocal winhl=NormalFloat:" .. normal .. ",FloatBorder:ZenBorder")
+  vim.cmd("setlocal winhl=NormalFloat:" .. normal .. ",FloatBorder:ZenBorder,EndOfBuffer:" .. normal)
   vim.cmd("setlocal winblend=0")
   vim.cmd([[setlocal fcs=eob:\ ,fold:\ ,vert:\]])
   -- vim.api.nvim_win_set_option(win, "winhighlight", "NormalFloat:" .. normal)


### PR DESCRIPTION
## Description

The `EndOfBuffer` highlight group can dominate the overlay, making it appear that the `window.backdrop` setting has no effect ([see comment](https://github.com/folke/zen-mode.nvim/issues/115#issuecomment-2265597204)).

To fix this, we should set not only `NormalFloat` to `ZenBg`, but `EndOfBuffer` too.

Alternative workaround: set `EndOfBuffer` to something else.

## Related Issue(s)

- https://github.com/folke/zen-mode.nvim/issues/115

## Screenshots

In the following, `window.backdrop` is set to `1`.

Before this PR, with a scheme that has `Normal` with `bg=#181818` and `EndOfBuffer` set to `bg=0`:

![before](https://github.com/user-attachments/assets/dcabb091-e28e-48b8-b996-39403b9f683f)

After:

![after](https://github.com/user-attachments/assets/bd22f773-a581-45e1-bf40-cb792bd7c529)