### PR TITLE
Add config option to not close zen-mode on WinEnter

### DIFF
--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -75,6 +75,7 @@ local defaults = {
         neovide_cursor_vfx_mode = "",
       },
     },
+    dont_exit_on_win_enter = { enabled = false }, -- If enabled, don't exit zen mode when a WinEnter event is fired. This happens if you click outside of the ZenMode window
   },
   -- callback where you can add custom code when the zen window opens
   on_open = function(_win) end,

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -201,16 +201,16 @@ function M.create(opts)
   -- TODO: listen for WinNew and BufEnter. When a new window, or bufenter in a new window, close zen mode
   -- unless it's in a float
   -- TODO: when the cursor leaves the window, we close zen mode, or prevent leaving the window
-  local augroup = [[
+  local augroup = string.format([[
     augroup Zen
       autocmd!
       autocmd WinClosed %d ++once ++nested lua require("zen-mode.view").close()
-      autocmd WinEnter * lua require("zen-mode.view").on_win_enter()
+      autocmd WinEnter * lua require("zen-mode.view").on_win_enter(%s)
       autocmd CursorMoved * lua require("zen-mode.view").fix_layout()
       autocmd VimResized * lua require("zen-mode.view").fix_layout(true)
       autocmd CursorHold * lua require("zen-mode.view").fix_layout()
       autocmd BufWinEnter * lua require("zen-mode.view").on_buf_win_enter()
-    augroup end]]
+    augroup end]], M.win, tostring(opts.dont_exit_on_win_enter))
 
   vim.api.nvim_exec(augroup:format(M.win, M.win), false)
 end
@@ -240,7 +240,11 @@ function M.on_buf_win_enter()
   end
 end
 
-function M.on_win_enter()
+function M.on_win_enter(dont_exit_on_win_enter)
+  if dont_exit_on_win_enter then
+    return M
+  end
+
   local win = vim.api.nvim_get_current_win()
   if win ~= M.win and not M.is_float(win) then
     -- HACK: when returning from a float window, vim initially enters the parent window.


### PR DESCRIPTION
## Description

I have mouse support enabled in neovim (:set mouse=nvi). When I click outside of the ZenMode panel, ZenMode is automatically exited. This often happens when I am in fullscreen mode and am working on a narrow-width buffer in ZenMode. It would be nice to be able to disable this behavior

## Related Issue(s)

Fix #151
