### PR TITLE
fixed crash and recommendation

### DIFF
--- a/lua/zen-mode/util.lua
+++ b/lua/zen-mode/util.lua
@@ -45,4 +45,31 @@ function M.error(msg)
   M.log(msg, "ErrorMsg")
 end
 
+---Need some kind of heuristics to determine if the
+---target buffer is a real file or not. For now, is as follow:
+function M.is_real_file()
+  local bufnr = vim.api.nvim_get_current_buf()
+  -- check if buf is nil or is not number which is not correct bufnr
+  if not bufnr or type(bufnr) ~= "number" then
+    return false
+  end
+
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return false
+  end
+
+  -- Assumed, any real file has a file name
+  local bufname = vim.api.nvim_buf_get_name(bufnr)
+  if bufname == "" then
+    return false
+  end
+
+  -- Also assumed, any file has some sort of file type
+  local filetype = vim.api.nvim_get_option_value("filetype", { buf = bufnr })
+  -- and should be listed(visible to users, us)
+  local buflisted = vim.api.nvim_get_option_value("buflisted", { buf = bufnr })
+
+  return filetype ~= "" and buflisted == true
+end
+
 return M

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -41,7 +41,7 @@ function M.close()
 
   -- Change the parent window's cursor position to match
   -- the cursor position in the zen-mode window.
-  if M.parent and M.win then
+  if M.parent and M.win and vim.api.nvim_win_is_valid(M.parent) and vim.api.nvim_win_is_valid(M.win) then
     -- Ensure that the parent window has the same buffer
     -- as the zen-mode window.
     if vim.api.nvim_win_get_buf(M.parent) == vim.api.nvim_win_get_buf(M.win) then

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -73,6 +73,10 @@ function M.close()
 end
 
 function M.open(opts)
+  if not util.is_real_file() then
+    return
+  end
+
   if not M.is_open() then
     -- close any possible remnants from a previous session
     -- shouldn't happen, but just in case


### PR DESCRIPTION
https://github.com/user-attachments/assets/1fae9440-7d95-4bd1-bd38-19c37f6d4bff

what I did is
- toggle neo-tree
- toggle zen mode
- toggle neo-tree again to close neo-tree
- zen mode crashes

I just put simple validation.

For the second commit, I'm thinking just handling this with key binding instead of limiting zen mode to text files only. Let me know what you think!

```lua
--before:
 if vim.api.nvim_win_is_valid(M.parent) and vim.api.nvim_win_is_valid(M.win) then
 

--after:
  if M.parent and M.win and vim.api.nvim_win_is_valid(M.parent) and vim.api.nvim_win_is_valid(M.win) then
```