### PR TITLE
feat(undotree plugin): adds undotree support and a sidecar concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,29 @@ require("zen-mode").toggle({
 
 ## 🧩 Plugins
 
+### Undotree
+
+Allows to keep showing undotree if it was active at the moment of zen-mode activation.
+By default shows section on the right side consuming 20% of specified zen-mode's `window.width`,
+can be customised to show on the left side with a desired relative width. It is recommended to
+increase your current `window.width` to accommodate for a sidecar's width.
+
+Example:
+```lua
+require("zen-mode").toggle({
+  window = {
+    width = .85 -- width will be 85% of the editor width
+  },
+  plugins = {
+    undotree = {
+      enabled = true,
+      width_relative = .2,
+      position = "right" -- or "left"
+    }
+  }
+})
+```
+
 ### Wezterm
 
 In order to make the integration with wezterm work as intended, you need to add

--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -85,6 +85,12 @@ local defaults = {
 ---@type ZenOptions
 M.options = nil
 
+---@class ZenEvents
+local event_type = { OPEN = "0", READY = "1", CLOSE = "2", LAYOUT_UPDATE = "3" }
+
+---@type ZenEvents
+M.event_type = event_type
+
 function M.colors(options)
   options = options or M.options
   local normal = util.get_hl("Normal")
@@ -92,8 +98,10 @@ function M.colors(options)
     if normal.background then
       local bg = util.darken(normal.background, options.window.backdrop)
       vim.cmd(("highlight default ZenBg guibg=%s guifg=%s"):format(bg, bg))
+      vim.cmd(("highlight default ZenSidecarBg guibg=%s guifg=%s"):format(bg, bg))
     else
       vim.cmd("highlight default link ZenBg Normal")
+      vim.cmd("highlight default link ZenSidecarBg Normal")
     end
   end
 end

--- a/lua/zen-mode/key.lua
+++ b/lua/zen-mode/key.lua
@@ -1,0 +1,52 @@
+local M = {}
+local ns_id = vim.api.nvim_create_namespace("zenmode_key")
+local listening = false
+
+---@class ZenNavKey
+M.nav_key = { WIN = "wincmd", LEFT = "left", UP = "up", RIGHT = "right", DOWN = "down" }
+
+-- last known recorded nav key
+---@type string
+M.last_nav_key_rec = nil
+
+-- detects moves across windows
+-- TODO: consider custom mappings support in config
+function M.listen()
+  if listening then
+    return ns_id
+  else
+    listening = true
+    vim.on_key(function(_, typed)
+      if typed and #typed > 0 then
+        local key = vim.fn.keytrans(typed)
+        local mod = key:match("^<([CMAD])%-.+>$")
+        if mod == "C" then
+          local move = key:match("^<.-%-.*(.)>$")
+          if move == "W" then
+            M.last_nav_key_rec = M.nav_key.WIN
+          end
+        else
+          if M.last_nav_key_rec == M.nav_key.WIN then
+            local move = key
+            if move == "h" then
+              M.last_nav_key_rec = M.nav_key.LEFT
+            elseif move == "j" then
+              M.last_nav_key_rec = M.nav_key.DOWN
+            elseif move == "k" then
+              M.last_nav_key_rec = M.nav_key.UP
+            elseif move == "l" then
+              M.last_nav_key_rec = M.nav_key.RIGHT
+            end
+          end
+        end
+      end
+    end, ns_id)
+  end
+end
+
+function M.stop_listen()
+  vim.on_key(nil, ns_id)
+  listening = false
+end
+
+return M

--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -1,16 +1,19 @@
+local util = require("zen-mode.util")
+local zconfig = require("zen-mode.config")
+
 local M = {}
 
-function M.gitsigns(state, disable)
+function M.gitsigns(state, event_type)
   local gs = require("gitsigns")
   local config = require("gitsigns.config").config
-  if disable then
+  if event_type == zconfig.event_type.OPEN then
     state.signcolumn = config.signcolumn
     state.numhl = config.numhl
     state.linehl = config.linehl
     config.signcolumn = false
     config.numhl = false
     config.linehl = false
-  else
+  elseif event_type == zconfig.event_type.CLOSE then
     config.signcolumn = state.signcolumn
     config.numhl = state.numhl
     config.linehl = state.linehl
@@ -18,13 +21,13 @@ function M.gitsigns(state, disable)
   gs.refresh()
 end
 
-function M.options(state, disable, opts)
+function M.options(state, event_type, opts)
   for key, value in pairs(opts) do
     if key ~= "enabled" then
-      if disable then
+      if event_type == zconfig.event_type.OPEN then
         state[key] = vim.o[key]
         vim.o[key] = value
-      else
+      elseif event_type == zconfig.event_type.CLOSE then
         vim.o[key] = state[key]
       end
     end
@@ -33,40 +36,40 @@ end
 
 -- changes the kitty font size
 -- it's a bit glitchy, but it works
-function M.kitty(state, disable, opts)
+function M.kitty(_, event_type, opts)
   if not vim.fn.executable("kitty") then
     return
   end
   local cmd = "kitty @ --to %s set-font-size %s"
   local socket = vim.fn.expand("$KITTY_LISTEN_ON")
-  if disable then
+  if event_type == zconfig.event_type.OPEN then
     vim.fn.system(cmd:format(socket, opts.font))
-  else
+  elseif event_type == zconfig.event_type.CLOSE then
     vim.fn.system(cmd:format(socket, "0"))
   end
   vim.cmd([[redraw]])
 end
 
 -- changes the alacritty font size
-function M.alacritty(state, disable, opts)
+function M.alacritty(state, event_type, opts)
   if not vim.fn.executable("alacritty") then
     return
   end
   local cmd = "alacritty msg config -w %s font.size=%s"
   local reset_cmd = "alacritty msg config -w %s --reset"
   local win_id = vim.fn.expand("$ALACRITTY_WINDOW_ID")
-  if disable then
+  if event_type == zconfig.event_type.OPEN then
     vim.fn.system(cmd:format(win_id, opts.font))
-  else
+  elseif event_type == zconfig.event_type.CLOSE then
     vim.fn.system(reset_cmd:format(win_id))
   end
   vim.cmd([[redraw]])
 end
 
 -- changes the wezterm font size
-function M.wezterm(state, disable, opts)
+function M.wezterm(state, event_type, opts)
   local stdout = vim.loop.new_tty(1, false)
-  if disable then
+  if event_type == zconfig.event_type.OPEN then
     -- Requires tmux setting or no effect: set-option -g allow-passthrough on
     stdout:write(
       ("\x1bPtmux;\x1b\x1b]1337;SetUserVar=%s=%s\b\x1b\\"):format(
@@ -74,7 +77,7 @@ function M.wezterm(state, disable, opts)
         vim.fn.system({ "base64" }, tostring(opts.font))
       )
     )
-  else
+  elseif event_type == zconfig.event_type.CLOSE then
     stdout:write(
       ("\x1bPtmux;\x1b\x1b]1337;SetUserVar=%s=%s\b\x1b\\"):format("ZEN_MODE", vim.fn.system({ "base64" }, "-1"))
     )
@@ -82,22 +85,22 @@ function M.wezterm(state, disable, opts)
   vim.cmd([[redraw]])
 end
 
-function M.twilight(state, disable)
-  if disable then
+function M.twilight(state, event_type)
+  if event_type == zconfig.event_type.OPEN then
     state.enabled = require("twilight.view").enabled
     require("twilight").enable()
-  else
+  elseif event_type == zconfig.event_type.CLOSE then
     if not state.enabled then
       require("twilight").disable()
     end
   end
 end
 
-function M.tmux(state, disable, opts)
+function M.tmux(state, event_type, _)
   if not vim.env.TMUX then
     return
   end
-  if disable then
+  if event_type == zconfig.event_type.OPEN then
     local function get_tmux_opt(option)
       local option_raw = vim.fn.system([[tmux show -w ]] .. option)
       if option_raw == "" then
@@ -112,7 +115,7 @@ function M.tmux(state, disable, opts)
     vim.fn.system([[tmux set -w pane-border-status off]])
     vim.fn.system([[tmux set status off]])
     vim.fn.system([[tmux list-panes -F '\#F' | grep -q Z || tmux resize-pane -Z]])
-  else
+  elseif event_type == zconfig.event_type.CLOSE then
     if type(state.pane) == "string" then
       vim.fn.system(string.format([[tmux set -w pane-border-status %s]], state.pane))
     else
@@ -123,11 +126,11 @@ function M.tmux(state, disable, opts)
   end
 end
 
-function M.neovide(state, disable, opts)
+function M.neovide(state, event_type, opts)
   if not vim.g.neovide then
     return
   end
-  if disable then
+  if event_type == zconfig.event_type.OPEN then
     if opts.scale ~= 1 then
       state.scale = vim.g.neovide_scale_factor
       vim.g.neovide_scale_factor = vim.g.neovide_scale_factor * opts.scale
@@ -138,7 +141,7 @@ function M.neovide(state, disable, opts)
         vim.g[key] = value
       end
     end
-  else
+  elseif event_type == zconfig.event_type.CLOSE then
     if opts.scale ~= 1 then
       vim.g.neovide_scale_factor = state.scale
     end
@@ -150,21 +153,158 @@ function M.neovide(state, disable, opts)
   end
 end
 
-function M.diagnostics(state, disable)
-  if disable then
-    vim.diagnostic.disable(0)
-  else
-    vim.diagnostic.enable(0)
+function M.diagnostics(state, event_type)
+  if event_type == zconfig.event_type.OPEN then
+    vim.diagnostic.enable(false)
+  elseif event_type == zconfig.event_type.CLOSE then
+    vim.diagnostic.enable(true)
   end
 end
 
-function M.todo(state, disable)
-  if disable then
+function M.todo(state, event_type)
+  if event_type == zconfig.event_type.OPEN then
     state.todo = require("todo-comments.highlight").enabled
     require("todo-comments").disable()
-  else
+  elseif event_type == zconfig.event_type.CLOSE then
     if state.todo then
       require("todo-comments").enable()
+    end
+  end
+end
+
+---@param state table - arbitrary map to store state in between events;
+---@param event_type ZenEvents - event to react on;
+---@param opts table - plugin options defined in the config;
+---@param sidecar ZenSidecar - side view which can be used to display plugin specific data;
+function M.undotree(state, event_type, opts, sidecar)
+  local function calc_tree_height(absolute, origin_tree_height, origin_diff_height)
+    local relative = origin_tree_height / (origin_diff_height + origin_tree_height)
+    return util.round(absolute * relative)
+  end
+
+  local function calc_diff_height(absolute, origin_tree_height, origin_diff_height)
+    local relative = origin_diff_height / (origin_diff_height + origin_tree_height)
+    return util.round(absolute * relative)
+  end
+
+  -- if undotree was open at the moment of zen activation, then show it, otherwise don't
+  if event_type == zconfig.event_type.OPEN then
+    local win_count = 0
+    for bufnr = 1, vim.fn.bufnr("$") do
+      if win_count == 2 then
+        break
+      end
+      if vim.fn.getbufvar(bufnr, "isUndotreeBuffer") == 1 then
+        local filetype = vim.fn.getbufvar(bufnr, "&filetype")
+
+        for _, win_id in pairs(vim.fn.win_findbuf(bufnr)) do
+          -- check that this is the one, it shouldn't happen, but just in case
+          if filetype == "undotree" then
+            -- main undotree window has been found
+            state.undotree_win = win_id
+            state.undotree_win_cfg = vim.api.nvim_win_get_config(win_id)
+            win_count = win_count + 1
+            state.undotree_win_height = vim.api.nvim_win_get_height(win_id)
+          elseif filetype == "diff" then
+            -- diff window
+            state.undodiff_win = win_id
+            state.undodiff_win_cfg = vim.api.nvim_win_get_config(win_id)
+            win_count = win_count + 1
+            state.undodiff_win_height = vim.api.nvim_win_get_height(win_id)
+          end
+        end
+      end
+    end
+
+    if win_count > 0 then
+      sidecar.registered = true
+      local relative_width = 0.2
+      local position = "right"
+      if opts.width_relative and opts.width_relative > 0 and opts.width_relative < 1 then
+        relative_width = opts.width_relative
+      end
+      if opts.position and opts.position == "left" then
+        position = "left"
+      end
+      sidecar.width_relative = relative_width
+      sidecar.position = position
+    end
+  elseif event_type == zconfig.event_type.READY or event_type == zconfig.event_type.LAYOUT_UPDATE then
+    local sidecar_win = sidecar.win
+    if not sidecar_win then
+      util.error("sidecar window is not set by zen view, undotree plugin can't bootstrap")
+      return
+    end
+    local sidecar_win_conf = vim.api.nvim_win_get_config(sidecar_win)
+
+    local new_tree_height =
+      calc_tree_height(sidecar_win_conf.height, state.undotree_win_height, state.undodiff_win_height)
+    local new_diff_height =
+      calc_diff_height(sidecar_win_conf.height, state.undotree_win_height, state.undodiff_win_height)
+    if state.undotree_win and vim.api.nvim_win_is_valid(state.undotree_win) then
+      local cfg = {
+        relative = "win",
+        win = sidecar_win,
+        zindex = sidecar_win_conf.zindex + 10,
+        width = sidecar_win_conf.width,
+        height = new_tree_height - 1,
+        row = 0,
+        col = 0,
+        style = "minimal",
+        border = "none",
+      }
+      if event_type == zconfig.event_type.READY then
+        local undotree_win_buf = vim.api.nvim_win_get_buf(state.undotree_win)
+        state.new_undotree_win = vim.api.nvim_open_win(undotree_win_buf, false, cfg)
+        sidecar.childs[#sidecar.childs + 1] = state.new_undotree_win
+      else
+        if vim.api.nvim_win_is_valid(state.new_undotree_win) then
+          vim.api.nvim_win_set_config(state.new_undotree_win, cfg)
+        else
+          state.new_undotree_win = nil
+          state.undotree_win = nil
+        end
+      end
+    end
+
+    if state.undodiff_win and vim.api.nvim_win_is_valid(state.undodiff_win) then
+      local cfg = {
+        relative = "win",
+        win = sidecar_win,
+        zindex = sidecar_win_conf.zindex + 10,
+        width = sidecar_win_conf.width,
+        height = new_diff_height,
+        row = new_tree_height,
+        col = 0,
+        style = "minimal",
+        border = "none",
+      }
+      if event_type == zconfig.event_type.READY then
+        local undodiff_win_buf = vim.api.nvim_win_get_buf(state.undodiff_win)
+        state.new_undodiff_win = vim.api.nvim_open_win(undodiff_win_buf, false, cfg)
+        sidecar.childs[#sidecar.childs + 1] = state.new_undodiff_win
+      else
+        if vim.api.nvim_win_is_valid(state.new_undodiff_win) then
+          vim.api.nvim_win_set_config(state.new_undodiff_win, cfg)
+        else
+          state.new_undodiff_win = nil
+          state.undodiff_win = nil
+        end
+      end
+    end
+  elseif event_type == zconfig.event_type.CLOSE then
+    if state.new_undotree_win and vim.api.nvim_win_is_valid(state.new_undotree_win) then
+      vim.api.nvim_win_close(state.new_undotree_win, true)
+      if state.undotree_win then
+        vim.api.nvim_win_set_height(state.undotree_win, state.undotree_win_height)
+      end
+    end
+    if state.new_undodiff_win and vim.api.nvim_win_is_valid(state.new_undodiff_win) then
+      vim.api.nvim_win_close(state.new_undodiff_win, true)
+      if state.undodiff_win then
+        -- HACK: weird off by 1 issue causing diff to shrink
+        vim.api.nvim_win_set_height(state.undodiff_win, state.undodiff_win_height)
+      end
     end
   end
 end

--- a/lua/zen-mode/util.lua
+++ b/lua/zen-mode/util.lua
@@ -33,6 +33,10 @@ function M.is_dark(hex)
   return lum <= 0.5
 end
 
+function M.round(num)
+  return math.floor(num + 0.5)
+end
+
 function M.log(msg, hl)
   vim.api.nvim_echo({ { "ZenMode: ", hl }, { msg } }, true, {})
 end

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -1,12 +1,33 @@
 local config = require("zen-mode.config")
+local key = require("zen-mode.key")
 local plugins = require("zen-mode.plugins")
 local util = require("zen-mode.util")
 local M = {}
+
+---@class ZenSidecar
+---@field win integer|nil - container window handle to use as the root for childs windows;
+---@field buf integer|nil - container throw away buffer;
+---@field registered boolean - indicates that at least 1 plugin registered a sidecar window;
+---@field position string|nil - sidecar position in related to main window 'left' or 'right';
+---@field childs table<integer> - array of child window handles;
+---@field child_ring_index integer - index of the last focused `childs` window
+local sidecar_default = {
+  win = nil,
+  buf = nil,
+  registered = false,
+  width_relative = 0.0,
+  position = nil,
+  childs = {},
+  child_ring_index = 1,
+}
 
 M.bg_win = nil
 M.bg_buf = nil
 M.parent = nil
 M.win = nil
+---@type ZenSidecar
+M.sidecar = vim.deepcopy(sidecar_default, true)
+M.last_active_zen_win = nil
 --- @type ZenOptions
 M.opts = nil
 M.state = {}
@@ -21,7 +42,25 @@ function M.plugins_on_open()
     if opts and opts.enabled then
       local plugin = plugins[name]
       M.state[name] = {}
-      pcall(plugin, M.state[name], true, opts)
+      pcall(plugin, M.state[name], config.event_type.OPEN, opts, M.sidecar)
+    end
+  end
+end
+
+function M.plugins_on_ready()
+  for name, opts in pairs(M.opts.plugins) do
+    if opts and opts.enabled then
+      local plugin = plugins[name]
+      pcall(plugin, M.state[name], config.event_type.READY, opts, M.sidecar)
+    end
+  end
+end
+
+function M.plugins_on_layout_update()
+  for name, opts in pairs(M.opts.plugins) do
+    if opts and opts.enabled then
+      local plugin = plugins[name]
+      pcall(plugin, M.state[name], config.event_type.LAYOUT_UPDATE, opts, M.sidecar)
     end
   end
 end
@@ -30,7 +69,7 @@ function M.plugins_on_close()
   for name, opts in pairs(M.opts.plugins) do
     if opts and opts.enabled then
       local plugin = plugins[name]
-      pcall(plugin, M.state[name], false, opts)
+      pcall(plugin, M.state[name], config.event_type.CLOSE, opts, M.sidecar)
     end
   end
 end
@@ -38,6 +77,7 @@ end
 function M.close()
   pcall(vim.cmd, [[autocmd! Zen]])
   pcall(vim.cmd, [[augroup! Zen]])
+  key.stop_listen()
 
   -- Change the parent window's cursor position to match
   -- the cursor position in the zen-mode window.
@@ -51,24 +91,40 @@ function M.close()
   end
 
   if M.win and vim.api.nvim_win_is_valid(M.win) then
-    vim.api.nvim_win_close(M.win, { force = true })
+    vim.api.nvim_win_close(M.win, true)
     M.win = nil
   end
   if M.bg_win and vim.api.nvim_win_is_valid(M.bg_win) then
-    vim.api.nvim_win_close(M.bg_win, { force = true })
+    vim.api.nvim_win_close(M.bg_win, true)
     M.bg_win = nil
   end
   if M.bg_buf and vim.api.nvim_buf_is_valid(M.bg_buf) then
     vim.api.nvim_buf_delete(M.bg_buf, { force = true })
     M.bg_buf = nil
   end
+
   if M.opts then
+    M.close_sidecar()
     M.plugins_on_close()
     M.opts.on_close()
     M.opts = nil
+    M.last_active_zen_win = nil
+    key.last_nav_key_rec = nil
     if M.parent and vim.api.nvim_win_is_valid(M.parent) then
       vim.api.nvim_set_current_win(M.parent)
     end
+  end
+end
+
+function M.close_sidecar()
+  if M.sidecar.registered then
+    if M.sidecar.win and vim.api.nvim_win_is_valid(M.sidecar.win) then
+      vim.api.nvim_win_close(M.sidecar.win, true)
+    end
+    if M.sidecar.buf and vim.api.nvim_buf_is_valid(M.sidecar.buf) then
+      vim.api.nvim_buf_delete(M.sidecar.buf, { force = true })
+    end
+    M.sidecar = vim.deepcopy(sidecar_default, true)
   end
 end
 
@@ -89,10 +145,6 @@ function M.toggle(opts)
   end
 end
 
-function M.round(num)
-  return math.floor(num + 0.5)
-end
-
 function M.height()
   local height = vim.o.lines - vim.o.cmdheight
   return (vim.o.laststatus == 3) and height - 1 or height
@@ -111,36 +163,79 @@ function M.resolve(max, value)
 end
 
 --- @param opts ZenOptions
-function M.layout(opts)
+function M.layout(opts, sidecar_width_relative, sidecar_position, is_sidecar)
+  local col_delta = 0
+  local width_delta = 0
+
   local width = M.resolve(vim.o.columns, opts.window.width)
   local height = M.resolve(M.height(), opts.window.height)
 
-  return {
-    width = M.round(width),
-    height = M.round(height),
-    col = M.round((vim.o.columns - width) / 2),
-    row = M.round((M.height() - height) / 2),
-  }
+  if sidecar_width_relative and sidecar_width_relative > 0 and sidecar_width_relative < 1 then
+    width_delta = util.round(sidecar_width_relative * width)
+  end
+
+  if is_sidecar then
+    if sidecar_position == "right" then
+      col_delta = util.round(width) - width_delta
+    end
+    return {
+      width = width_delta,
+      height = util.round(height),
+      col = util.round((vim.o.columns - width) / 2) + col_delta,
+      row = util.round((M.height() - height) / 2),
+    }
+  else
+    if sidecar_position == "left" then
+      col_delta = width_delta
+    end
+    return {
+      width = util.round(width) - width_delta,
+      height = util.round(height),
+      col = util.round((vim.o.columns - width) / 2) + col_delta,
+      row = util.round((M.height() - height) / 2),
+    }
+  end
 end
 
 -- adjusts col/row if window was resized
 function M.fix_layout(win_resized)
   if M.is_open() then
-    if win_resized then
-      local l = M.layout(M.opts)
-      vim.api.nvim_win_set_config(M.win, { width = l.width, height = l.height })
-      vim.api.nvim_win_set_config(M.bg_win, { width = vim.o.columns, height = M.height() })
+    local win_layout
+    local side_layout
+    if
+      M.sidecar.registered
+      and M.sidecar.win
+      and vim.api.nvim_win_is_valid(M.sidecar.win)
+      and #M.sidecar.childs ~= 0
+    then
+      side_layout = M.layout(M.opts, M.sidecar.width_relative, M.sidecar.position, true)
+      win_layout = M.layout(M.opts, M.sidecar.width_relative, M.sidecar.position, false)
+    else
+      win_layout = M.layout(M.opts)
     end
-    local height = vim.api.nvim_win_get_height(M.win)
-    local width = vim.api.nvim_win_get_width(M.win)
-    local col = M.round((vim.o.columns - width) / 2)
-    local row = M.round((M.height() - height) / 2)
-    local cfg = vim.api.nvim_win_get_config(M.win)
-    -- HACK: col is an array?
-    local wcol = type(cfg.col) == "number" and cfg.col or cfg.col[false]
-    local wrow = type(cfg.row) == "number" and cfg.row or cfg.row[false]
-    if wrow ~= row or wcol ~= col then
-      vim.api.nvim_win_set_config(M.win, { col = col, row = row, relative = "editor" })
+
+    if win_resized then
+      vim.api.nvim_win_set_config(M.win, { width = win_layout.width, height = win_layout.height })
+      vim.api.nvim_win_set_config(M.bg_win, { width = vim.o.columns, height = M.height() })
+      if side_layout then
+        vim.api.nvim_win_set_config(M.sidecar.win, { width = side_layout.width, height = side_layout.height })
+      end
+    end
+
+    local function update_col_row_if_needed(win, col, row)
+      local cfg = vim.api.nvim_win_get_config(win)
+      -- HACK: col is an array?
+      local wcol = type(cfg.col) == "number" and cfg.col or cfg.col[false]
+      local wrow = type(cfg.row) == "number" and cfg.row or cfg.row[false]
+      if wrow ~= row or wcol ~= col then
+        vim.api.nvim_win_set_config(win, { col = col, row = row, relative = "editor" })
+      end
+    end
+
+    update_col_row_if_needed(M.win, win_layout.col, win_layout.row)
+    if side_layout then
+      update_col_row_if_needed(M.sidecar.win, side_layout.col, side_layout.row)
+      M.plugins_on_layout_update()
     end
   end
 end
@@ -176,11 +271,31 @@ function M.create(opts)
   end
   M.fix_hl(M.bg_win, "ZenBg")
 
+  local win_layout
+  -- check if any plugin has registered a sidecar
+  if M.sidecar.registered == true then
+    local sidecar_win_opts = vim.tbl_extend("keep", {
+      relative = "editor",
+      style = "minimal",
+      border = "none",
+      zindex = opts.zindex - 10,
+      focusable = false,
+    }, M.layout(opts, M.sidecar.width_relative, M.sidecar.position, true))
+    M.sidecar.buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_option(M.sidecar.buf, "filetype", "zenmode-sidecar")
+    M.sidecar.win = vim.api.nvim_open_win(M.sidecar.buf, false, sidecar_win_opts)
+    M.fix_hl(M.sidecar.win, "ZenSidecarBg")
+
+    win_layout = M.layout(opts, M.sidecar.width_relative, M.sidecar.position, false)
+  else
+    win_layout = M.layout(opts)
+  end
+
   local win_opts = vim.tbl_extend("keep", {
     relative = "editor",
     zindex = opts.zindex,
     border = opts.border,
-  }, M.layout(opts))
+  }, win_layout)
 
   local buf = vim.api.nvim_get_current_buf()
   M.win = vim.api.nvim_open_win(buf, true, win_opts)
@@ -191,28 +306,49 @@ function M.create(opts)
     vim.api.nvim_win_set_option(M.win, k, v)
   end
 
+  -- allow to render inside sidecar
+  M.plugins_on_ready()
+  if M.sidecar.registered then
+    for _, win_id in ipairs(M.sidecar.childs) do
+      M.fix_hl(win_id)
+    end
+  end
+
   if type(opts.on_open) == "function" then
     opts.on_open(M.win)
   end
-
   -- fix layout since some plugins might have altered the window
   M.fix_layout()
 
-  -- TODO: listen for WinNew and BufEnter. When a new window, or bufenter in a new window, close zen mode
-  -- unless it's in a float
-  -- TODO: when the cursor leaves the window, we close zen mode, or prevent leaving the window
+  -- NOTE: listen for WinNew and BufEnter. When a new window, or bufenter in a new window, close zen mode
+  -- unless it's in a float or sidecar
+  -- NOTE: when the cursor leaves the window, we close zen mode, or prevent leaving the window
   local augroup = [[
     augroup Zen
       autocmd!
       autocmd WinClosed %d ++once ++nested lua require("zen-mode.view").close()
+      autocmd WinClosed * lua require("zen-mode.view").on_win_close()
       autocmd WinEnter * lua require("zen-mode.view").on_win_enter()
+      autocmd WinLeave * lua require("zen-mode.view").on_win_leave()
       autocmd CursorMoved * lua require("zen-mode.view").fix_layout()
       autocmd VimResized * lua require("zen-mode.view").fix_layout(true)
       autocmd CursorHold * lua require("zen-mode.view").fix_layout()
       autocmd BufWinEnter * lua require("zen-mode.view").on_buf_win_enter()
     augroup end]]
 
-  vim.api.nvim_exec(augroup:format(M.win, M.win), false)
+  -- FIX: It could have been an easy win, but focusable doesn't work on non-floating windows.
+  -- [https://github.com/neovim/neovim/issues/29365](issue)
+  -- for _, win_obj in ipairs(vim.fn.getwininfo()) do
+  --   local cfg = vim.api.nvim_win_get_config(win_obj.winid)
+  --   if cfg.relative and cfg.relative == "" then
+  --     vim.api.nvim_win_set_config(win_obj.winid, { focusable = false })
+  --   end
+  -- end
+  --
+  -- instead custom navigation mappings implemented
+  key.listen()
+
+  vim.api.nvim_exec2(augroup:format(M.win, M.win), { output = false })
 end
 
 function M.fix_hl(win, normal)
@@ -226,7 +362,9 @@ function M.fix_hl(win, normal)
   vim.cmd([[setlocal fcs=eob:\ ,fold:\ ,vert:\]])
   -- vim.api.nvim_win_set_option(win, "winhighlight", "NormalFloat:" .. normal)
   -- vim.api.nvim_win_set_option(win, "fcs", "eob: ")
-  vim.api.nvim_set_current_win(cwin)
+  if vim.api.nvim_win_is_valid(cwin) then
+    vim.api.nvim_set_current_win(cwin)
+  end
 end
 
 function M.is_float(win)
@@ -235,22 +373,120 @@ function M.is_float(win)
 end
 
 function M.on_buf_win_enter()
-  if vim.api.nvim_get_current_win() == M.win then
-    M.fix_hl(M.win)
+  local cwin = vim.api.nvim_get_current_win()
+  if cwin == M.win or M.is_in_sidecar(cwin) then
+    M.fix_hl(cwin)
+  end
+end
+
+function M.on_win_leave()
+  local win = vim.api.nvim_get_current_win()
+  if M.is_zen_window(win) then
+    M.last_active_zen_win = win
+  end
+end
+
+function M.on_win_close()
+  for i, win_id in ipairs(M.sidecar.childs) do
+    if not vim.api.nvim_win_is_valid(win_id) then
+      table.remove(M.sidecar.childs, i)
+      M.sidecar.child_ring_index = 1
+      if M.last_active_zen_win == win_id then
+        M.last_active_zen_win = M.win
+      end
+      M.jump_to_win(M.win)
+    end
+  end
+  if M.sidecar.win and #M.sidecar.childs == 0 then
+    M.close_sidecar()
+    M.fix_layout(true)
   end
 end
 
 function M.on_win_enter()
   local win = vim.api.nvim_get_current_win()
-  if win ~= M.win and not M.is_float(win) then
-    -- HACK: when returning from a float window, vim initially enters the parent window.
-    -- give 10ms to get back to the zen window before closing
-    vim.defer_fn(function()
-      if vim.api.nvim_get_current_win() ~= M.win then
-        M.close()
-      end
-    end, 10)
+  if not M.is_zen_window(win) then
+    if M.sidecar.registered and #M.sidecar.childs ~= 0 then
+      -- HACK: when returning from a float window, vim initially enters the parent window.
+      -- give 10ms to get back to the zen window before closing
+      -- it also gives a nasty cursor blink when navigating across floating windows, worth
+      -- to fix somehow
+      vim.defer_fn(M.handle_win_jumps, 10)
+    else
+      M.close()
+    end
   end
+end
+
+function M.handle_win_jumps()
+  local win = vim.api.nvim_get_current_win()
+  if not M.is_zen_window(win) and not M.is_float(win) then
+    if M.sidecar.registered then
+      -- jump between main and sidecar
+      if M.last_active_zen_win == M.win then
+        if key.last_nav_key_rec == key.nav_key.UP or key.last_nav_key_rec == key.nav_key.DOWN then
+          -- get back to main window (no move)
+          M.jump_to_win(M.win)
+        else
+          local first_child_win = M.sidecar.childs[1]
+          if first_child_win then
+            M.jump_to_win(first_child_win)
+          end
+        end
+      else
+        if key.last_nav_key_rec == key.nav_key.LEFT or key.last_nav_key_rec == key.nav_key.RIGHT then
+          M.jump_to_win(M.win)
+          M.sidecar.child_ring_index = 1
+        else
+          local new_index = M.sidecar.child_ring_index
+          if key.last_nav_key_rec == key.nav_key.UP then
+            new_index = new_index - 1
+          end
+          if key.last_nav_key_rec == key.nav_key.DOWN then
+            new_index = new_index + 1
+          end
+          if new_index > #M.sidecar.childs or new_index <= 0 then
+            -- get back to sidecar (no move)
+            M.jump_to_win(M.sidecar.childs[M.sidecar.child_ring_index])
+          else
+            M.jump_to_win(M.sidecar.childs[new_index])
+            M.sidecar.child_ring_index = new_index
+          end
+        end
+      end
+    else
+      -- no sindecar configured, just leave
+      M.close()
+    end
+  else
+    -- HACK: Doesn't track curosr position in the main window without moving back and forth
+    if M.sidecar.registered and #M.sidecar.childs > 0 then
+      M.jump_to_win(M.win)
+      M.jump_to_win(M.sidecar.childs[1])
+    end
+  end
+end
+
+function M.jump_to_win(win)
+  if not vim.api.nvim_win_is_valid(win) then
+    return
+  end
+  local cmd = ("%dwincmd w"):format(vim.api.nvim_win_get_number(win))
+  vim.api.nvim_exec2(cmd, { output = false })
+  key.last_nav_key_rec = nil
+end
+
+function M.is_zen_window(win)
+  return win == M.win or M.is_in_sidecar(win)
+end
+
+function M.is_in_sidecar(win)
+  for _, win_id in ipairs(M.sidecar.childs) do
+    if win_id == win then
+      return true
+    end
+  end
+  return false
 end
 
 return M


### PR DESCRIPTION
## Description

For those who can't imagine coding without [undotree](https://github.com/mbbill/undotree) even in a chill mode. 

The initial idea was to somehow fit it into the existing zen-mode's plugin concept, but I've quickly realised that to make it happen a new "sidecar-plugin" concept has to emerge, it effectively allows any other plugin to attach its window(s) to the main zen-view to the left or right. Since the idea of zen-mode is to not overload user with the information, only one plugin is allowed to register a sidecar.
There's a few minor places where Im not completely happy with the solution, to be specific:
* It turns out it is quite an unpleasant experience to deal with the navigation across floating windows in nvim, here's a [related issue](https://github.com/neovim/neovim/issues/29365). In order to make it happen it was decided to do some custom key-listening and intercepting user's windows movements.
* here's a short cursor glitch when switching between main and sidecar window due to the fact nvim has to return to "hidden" parrent window before getting back to floatings, I didn't come up with any sensible workaround for this, so fix is welcome. 
Other than that it should work smoothly, at least I've been already using it for a while and didn't find any experience-breaking issues.


## Screenshots
![Screenshot 2024-11-24 at 20 25 20](https://github.com/user-attachments/assets/77bf16ae-0753-43db-b5f4-511404b7ae1b)
![Screenshot 2024-11-24 at 20 26 20](https://github.com/user-attachments/assets/dbb3a677-3c3b-41b3-b234-cca751c4a399)
![Screenshot 2024-11-24 at 20 28 02](https://github.com/user-attachments/assets/72fd6f4c-d5c9-45c6-8456-d140886f331d)



