### PR TITLE
fix(border): set window border to none

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -166,6 +166,7 @@ function M.create(opts)
     row = 0,
     col = 0,
     style = "minimal",
+    border = "none",
     zindex = opts.zindex - 10,
   })
   if not ok then


### PR DESCRIPTION
## Description

Set window border to none in case that the user sets a different `winborder`.

## Related Issue(s)

This fixes #184

## Screenshots

`winborder=round` without this PR:

![image](https://github.com/user-attachments/assets/2f008ef2-7253-4a0c-abba-0ad2f454b331)

