### PR TITLE
feat(kitty): add layout option to maximize window in Zen Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Distraction-free coding for Neovim >= 0.5
 - plugins:
   - disable gitsigns
   - hide [tmux](https://github.com/tmux/tmux) status line
-  - increase [Kitty](https://sw.kovidgoyal.net/kitty/) font-size
+  - increase [Kitty](https://sw.kovidgoyal.net/kitty/) font-size and sets layout
   - increase [Alacritty](https://alacritty.org/) font-size
   - increase [wezterm](https://wezfurlong.org/wezterm/) font-size
   - increase [Neovide](https://neovide.dev/) scale factor and disable animations
@@ -92,13 +92,15 @@ Install the plugin with your preferred package manager:
     gitsigns = { enabled = false }, -- disables git signs
     tmux = { enabled = false }, -- disables the tmux statusline
     todo = { enabled = false }, -- if set to "true", todo-comments.nvim highlights will be disabled
-    -- this will change the font size on kitty when in zen mode
+    -- this will change the font size and layout on kitty when in zen mode
+    -- the "stack" layout maximizes (fullscreen) the current kitty window and exiting zen mode restores the previous layout
     -- to make this work, you need to set the following kitty options:
     -- - allow_remote_control socket-only
     -- - listen_on unix:/tmp/kitty
     kitty = {
       enabled = false,
       font = "+4", -- font size increment
+      layout = "stack" -- sets layout in zen mode, "stack" maximizes the current window
     },
     -- this will change the font size on alacritty when in zen mode
     -- requires  Alacritty Version 0.10.0 or higher

--- a/doc/zen-mode.nvim.txt
+++ b/doc/zen-mode.nvim.txt
@@ -33,7 +33,8 @@ FEATURES                                     *zen-mode.nvim-zen-mode-features*
 - plugins:
     - disable gitsigns
     - hide tmux <https://github.com/tmux/tmux> status line
-    - increase Kitty <https://sw.kovidgoyal.net/kitty/> font-size
+    - increase Kitty <https://sw.kovidgoyal.net/kitty/> font-size and set
+      layout
     - increase Alacritty <https://alacritty.org/> font-size
     - increase wezterm <https://wezfurlong.org/wezterm/> font-size
     - increase Neovide <https://neovide.dev/> scale factor and disable animations
@@ -111,13 +112,15 @@ CONFIGURATION                           *zen-mode.nvim-zen-mode-configuration*
         gitsigns = { enabled = false }, -- disables git signs
         tmux = { enabled = false }, -- disables the tmux statusline
         todo = { enabled = false }, -- if set to "true", todo-comments.nvim highlights will be disabled
-        -- this will change the font size on kitty when in zen mode
+	-- this will change the font size and layout on kitty when in zen mode
+	-- the "stack" layout maximizes (fullscreen) the current kitty window and exiting zen mode restores the previous layout
         -- to make this work, you need to set the following kitty options:
         -- - allow_remote_control socket-only
         -- - listen_on unix:/tmp/kitty
         kitty = {
           enabled = false,
           font = "+4", -- font size increment
+	  layout = "stack" -- sets layout in zen mode, "stack" maximizes the current window
         },
         -- this will change the font size on alacritty when in zen mode
         -- requires  Alacritty Version 0.10.0 or higher

--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -37,13 +37,15 @@ local defaults = {
     tmux = { enabled = false }, -- disables the tmux statusline
     diagnostics = { enabled = false }, -- disables diagnostics
     todo = { enabled = false }, -- if set to "true", todo-comments.nvim highlights will be disabled
-    -- this will change the font size on kitty when in zen mode
+    -- this will change the font size and layout on kitty when in zen mode
+    -- the "stack" layout maximizes (fullscreen) the current kitty window and exiting zen mode restores the previous layout
     -- to make this work, you need to set the following kitty options:
     -- - allow_remote_control socket-only
     -- - listen_on unix:/tmp/kitty
     kitty = {
       enabled = false,
       font = "+4", -- font size increment
+      layout = "stack" -- sets layout in zen mode, "stack" maximizes the current window
     },
     -- this will change the font size on alacritty when in zen mode
     -- requires  Alacritty Version 0.10.0 or higher

--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -31,20 +31,43 @@ function M.options(state, disable, opts)
   end
 end
 
--- changes the kitty font size
--- it's a bit glitchy, but it works
 function M.kitty(state, disable, opts)
   if not vim.fn.executable("kitty") then
     return
   end
-  local cmd = "kitty @ --to %s set-font-size %s"
+
   local socket = vim.fn.expand("$KITTY_LISTEN_ON")
-  if disable then
-    vim.fn.system(cmd:format(socket, opts.font))
-  else
-    vim.fn.system(cmd:format(socket, "0"))
+  if socket == "" then
+    vim.notify(
+      "Zen-mode: KITTY_LISTEN_ON is not set. Kitty integration disabled.",
+      vim.log.levels.WARN
+    )
+    return
   end
-  vim.cmd([[redraw]])
+
+  local base_cmd = { "kitty", "@", "--to", socket }
+
+  if disable then
+    if opts.font then
+      local font_cmd = vim.list_extend(vim.deepcopy(base_cmd), { "set-font-size", opts.font })
+      vim.fn.system(font_cmd)
+    end
+    if opts.layout and type(opts.layout) == "string" then
+      local layout_cmd = vim.list_extend(vim.deepcopy(base_cmd), { "goto-layout", opts.layout })
+      vim.fn.system(layout_cmd)
+    end
+  else
+    if opts.font then
+      local font_cmd = vim.list_extend(vim.deepcopy(base_cmd), { "set-font-size", "0" })
+      vim.fn.system(font_cmd)
+    end
+    if opts.layout and type(opts.layout) == "string" then
+      local layout_cmd = vim.list_extend(vim.deepcopy(base_cmd), { "last-used-layout" })
+      vim.fn.system(layout_cmd)
+    end
+  end
+
+  vim.cmd([[redraw!]])
 end
 
 -- changes the alacritty font size


### PR DESCRIPTION
This PR adds support for changing the Kitty layout in addition to font size when entering Zen Mode.

Introduces a new layout option under the kitty configuration.

Using the stack layout will maximize (fullscreen) the current Kitty window when entering Zen Mode and restore the previous layout on exit.

Updated documentation (README.md, doc/zen-mode.nvim.txt) to reflect the new option and required Kitty settings.

This allows Kitty users (like myself) to have their current window maximized automatically when entering Zen Mode for a more distraction-free workflow.