### PR TITLE
fix(border): disable bg window border

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -159,6 +159,7 @@ function M.create(opts)
   vim.api.nvim_buf_set_option(M.bg_buf, "filetype", "zenmode-bg")
   local ok
   ok, M.bg_win = pcall(vim.api.nvim_open_win, M.bg_buf, false, {
+    border = "",
     relative = "editor",
     width = vim.o.columns,
     height = M.height(),


### PR DESCRIPTION
Problem:
Since Nvim added the 'winborder' global option, `nvim_open_win` defaults to it. But for zen-mode's background window, it makes sense to default to "no border".

Solution:
When creating bg_win, explicitly pass empty `border`.

fix #185

