### PR TITLE
feat(main): add option to sync current editable buffer with parent buffer

### DIFF
--- a/lua/zen-mode/config.lua
+++ b/lua/zen-mode/config.lua
@@ -75,6 +75,9 @@ local defaults = {
         neovide_cursor_vfx_mode = "",
       },
     },
+    -- keep the parent window's buffer in sync with the zen window
+    -- useful for preserving buffer state (e.g., LSP) when switching buffers in zen mode
+    sync_parent_buffer = { enabled = true },
   },
   -- callback where you can add custom code when the zen window opens
   on_open = function(_win) end,

--- a/lua/zen-mode/plugins.lua
+++ b/lua/zen-mode/plugins.lua
@@ -169,4 +169,9 @@ function M.todo(state, disable)
   end
 end
 
+function M.sync_parent_buffer(state, disable)
+  local view = require("zen-mode.view")
+  view.sync_parent_buffer_enabled = disable
+end
+
 return M

--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -11,6 +11,7 @@ M.win = nil
 M.opts = nil
 M.state = {}
 M.closed = false
+M.sync_parent_buffer_enabled = false
 
 function M.is_open()
   return M.win and vim.api.nvim_win_is_valid(M.win)
@@ -211,6 +212,7 @@ function M.create(opts)
       autocmd VimResized * lua require("zen-mode.view").fix_layout(true)
       autocmd CursorHold * lua require("zen-mode.view").fix_layout()
       autocmd BufWinEnter * lua require("zen-mode.view").on_buf_win_enter()
+      autocmd BufEnter * lua require("zen-mode.view").sync_parent_buffer()
     augroup end]]
 
   vim.api.nvim_exec(augroup:format(M.win, M.win), false)
@@ -238,6 +240,16 @@ end
 function M.on_buf_win_enter()
   if vim.api.nvim_get_current_win() == M.win then
     M.fix_hl(M.win)
+  end
+end
+
+function M.sync_parent_buffer()
+  if not M.sync_parent_buffer_enabled then
+    return
+  end
+  if M.is_open() and M.parent and vim.api.nvim_win_is_valid(M.parent) then
+    local zen_buf = vim.api.nvim_win_get_buf(M.win)
+    vim.api.nvim_win_set_buf(M.parent, zen_buf)
   end
 end
 


### PR DESCRIPTION
This pull request introduces a new feature that keeps the parent window's buffer in sync with the zen window in Zen Mode, which is particularly useful for preserving buffer state (such as LSP) when switching buffers. The implementation includes a new configuration option, supporting logic, and event-driven synchronization.

**Feature: Parent Buffer Synchronization**

* Added a `sync_parent_buffer` configuration option (enabled by default) to the Zen Mode setup, allowing users to keep the parent window's buffer synchronized with the zen window.
* Introduced the `sync_parent_buffer_enabled` flag and related logic in `view.lua` to control whether buffer synchronization is active.
* Added an autocommand on `BufEnter` to trigger buffer synchronization between the zen window and its parent window.
* Implemented the `sync_parent_buffer` function in `view.lua` to perform the actual buffer synchronization when appropriate.
* Exposed a new `sync_parent_buffer` function in `plugins.lua` to allow toggling the synchronization feature programmatically.