### PR TITLE
fix: don't run zz in terminal buffers (#163)

### DIFF
--- a/lua/zen-mode/view.lua
+++ b/lua/zen-mode/view.lua
@@ -184,8 +184,11 @@ function M.create(opts)
   }, M.layout(opts))
 
   local buf = vim.api.nvim_get_current_buf()
+  local is_terminal_mode = vim.api.nvim_get_mode().mode == "t"
   M.win = vim.api.nvim_open_win(buf, true, win_opts)
-  vim.cmd([[norm! zz]])
+  if not is_terminal_mode then
+    vim.cmd([[norm! zz]])
+  end
   M.fix_hl(M.win)
 
   for k, v in pairs(opts.window.options or {}) do


### PR DESCRIPTION
## Description

Fix bug #163 by not running `norm! zz` if in terminal mode. Without the fix it throws an error. This only happens when in a terminal buffer in insert mode (mode 't').

## Related Issue(s)

Originally reported in #163, but closed as not planned. Looks like there used to be a separate PR a long time ago #89 that also fixed this, but was closed by the author. This fix differs slightly from #89 in that I only check for mode t, since a terminal buffer that's in normal/visual mode will still want norm! zz.
